### PR TITLE
Added the recent contests given by user slash command

### DIFF
--- a/cogs/contests.py
+++ b/cogs/contests.py
@@ -1,9 +1,8 @@
-import random
-import discord
 import requests
 from datetime import datetime
 from discord import *
 from discord.ext import commands
+from bs4 import BeautifulSoup
 
 
 def fetch_upcoming_contests():
@@ -67,6 +66,100 @@ def fetch_upcoming_contests():
     return upcoming_contests
 
 
+def codeforces_contests_given_by_user(handle: str) -> Embed:
+    url = f"https://codeforces.com/api/user.rating?handle={handle}"
+    response = requests.get(url)
+    data = response.json()
+
+    if data["status"] != "OK":
+        return Embed(
+            title="Error",
+            description="Error fetching data from Codeforces API",
+            color=0xFF0000,
+        )
+
+    contests = sorted(
+        data["result"], key=lambda x: x["ratingUpdateTimeSeconds"], reverse=True
+    )
+
+    recent_contests = contests[:5]
+
+    embed = Embed(
+        title=f"Recent contests of {handle}",
+        description="Here are the 5 most recent contests participated in by the user:",
+        color=0x00FF00,
+    )
+
+    for contest in recent_contests:
+        contest_name = contest["contestName"]
+        rank = contest["rank"]
+        old_rating = contest["oldRating"]
+        new_rating = contest["newRating"]
+        diff = new_rating - old_rating
+
+        field_name = "Contest Details"
+        field_value = f"**Contest:** {contest_name}\n"
+        field_value += f"**Rank:** {rank}\n"
+        field_value += f"**Old Rating:** {old_rating}\n"
+        field_value += f"**New Rating:** {new_rating}\n"
+        field_value += f"**Diff:** {diff}"
+
+        embed.add_field(name=field_name, value=field_value, inline=False)
+
+    return embed
+
+
+def atcoder_contests_given_by_user(username: str):
+    url = f"https://atcoder.jp/users/{username}/history"
+    response = requests.get(url)
+    soup = BeautifulSoup(response.text, "html.parser")
+    contest_rows = soup.select("table#history tbody tr")
+    contests = []
+    for row in contest_rows:
+        date = row.select_one("td[data-order]").text.strip()
+        contest_name = row.select_one("td.text-left a").text.strip()
+        rank = row.select_one("td:nth-child(3) a").text.strip()
+        performance = row.select_one("td:nth-child(4)").text.strip()
+        new_rating = row.select_one("td:nth-child(5) span").text.strip()
+        diff = row.select_one("td:nth-child(6)").text.strip()
+
+        contests.append(
+            {
+                "Date": date,
+                "Contest": contest_name,
+                "Rank": rank,
+                "Performance": performance,
+                "New Rating": new_rating,
+                "Diff": diff,
+            }
+        )
+    embed = Embed(
+        title="Contest History",
+        description="Here are the contests participated in by the user:",
+        color=0x00FF00,
+    )
+
+    for contest in contests:
+        contest_name = contest["Contest"]
+        start_time = contest["Date"]
+        rank = contest["Rank"]
+        performance = contest["Performance"]
+        new_rating = contest["New Rating"]
+        diff = contest["Diff"]
+
+        field_name = "Contest Details"
+        field_value = f"**Contest:** {contest_name}\n"
+        field_value += f"**Start Time:** {start_time}\n"
+        field_value += f"**Rank:** {rank}\n"
+        field_value += f"**Performance:** {performance}\n"
+        field_value += f"**New Rating:** {new_rating}\n"
+        field_value += f"**Diff:** {diff}"
+
+        embed.add_field(name=field_name, value=field_value, inline=False)
+
+    return embed
+
+
 class contests(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
@@ -98,6 +191,24 @@ class contests(commands.Cog):
             response.add_field(name=field_name, value=field_value, inline=False)
 
         await ctx.respond(embed=response)
+
+    @commands.slash_command(
+        description="Get the list of the recent 5 contests given by you on the website "
+    )
+    async def recent_contest(self, ctx: commands.Context, website: str, username: str):
+        website_to_function = {
+            "codeforces": codeforces_contests_given_by_user,
+            "atcoder": atcoder_contests_given_by_user,
+        }
+
+        if website.lower().rstrip().lstrip() in website_to_function:
+            embed = website_to_function[website](username)
+            if embed is None:
+                await ctx.respond("Invalid username")
+                return
+            await ctx.respond(embed=embed)
+        else:
+            await ctx.respond("Invalid Website")
 
 
 def setup(bot: commands.Bot):

--- a/cogs/cp_profiles/LeetCode.py
+++ b/cogs/cp_profiles/LeetCode.py
@@ -12,7 +12,9 @@ def getLeetCodeEmbed(username: str) -> Embed | None:
     embed = Embed(title=username, color=0x00FF00)
     embed.set_author(
         name="LeetCode",
-        icon_url="https://www.google.com/url?sa=i&url=https%3A%2F%2Fleetcode.com%2F&psig=AOvVaw1bZXtsAts5pg_h6It7I9kX&ust=1695556446675000&source=images&cd=vfe&opi=89978449&ved=0CBAQjRxqFwoTCOi11o_WwIEDFQAAAAAdAAAAABAE",
+        icon_url="https://www.google.com/url?sa=i&url=https%3A%2F%2Fleetcode.com%2F&psig=AOvVaw1bZXtsAts5pg_h6It7I9kX"
+        "&ust=1695556446675000&source=images&cd=vfe&opi=89978449&ved"
+        "=0CBAQjRxqFwoTCOi11o_WwIEDFQAAAAAdAAAAABAE",
     )
     embed.add_field(name="Handle", value=f"[{username}]({profile_url})", inline=False)
     embed.add_field(name="Ranking", value=data["ranking"], inline=False)


### PR DESCRIPTION
Solves #23 

Implemented the `/recent_contest` slash command. It takes website and username as the input and return the recent 5 contests given by the user

Changes:
- Created the `recent_contests` command in `contests.py` file in the `cogs` folder